### PR TITLE
feat: add download for gmaps (raw) dataset

### DIFF
--- a/docs/core.html
+++ b/docs/core.html
@@ -37,7 +37,8 @@ summary: "API details."
     
     <span class="n">name_to_id</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;embeddings&#39;</span><span class="p">:</span> <span class="s1">&#39;1dRwSXbFTcQbn8c3V24G92wFY4DXZ1SDt&#39;</span><span class="p">,</span>
                   <span class="s1">&#39;imdb&#39;</span><span class="p">:</span> <span class="s1">&#39;1wF0YEmQOwceJz2d6w4CfhBgydU87dPGl&#39;</span><span class="p">,</span>
-                  <span class="s1">&#39;housing&#39;</span><span class="p">:</span> <span class="s1">&#39;1d7oOKdDmZFx8wf0c8OfuTW1FpUyJHABh&#39;</span><span class="p">}</span>
+                  <span class="s1">&#39;housing&#39;</span><span class="p">:</span> <span class="s1">&#39;1d7oOKdDmZFx8wf0c8OfuTW1FpUyJHABh&#39;</span><span class="p">,</span>
+                  <span class="s1">&#39;housing_gmaps&#39;</span><span class="p">:</span> <span class="s1">&#39;1R1RUHAXxzrIngRJMFwyp4vZRVICd-I6T&#39;</span><span class="p">}</span>
     
     <span class="k">if</span> <span class="n">dataset_name</span> <span class="ow">in</span> <span class="n">name_to_id</span><span class="p">:</span>
         <span class="k">try</span><span class="p">:</span>
@@ -130,6 +131,33 @@ summary: "API details."
 
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Download of imdb dataset complete.
+</pre>
+</div>
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">get_dataset</span><span class="p">(</span><span class="s1">&#39;housing_gmaps&#39;</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+<div class="output_area">
+
+<div class="output_subarea output_stream output_stdout output_text">
+<pre>Download of housing_gmaps dataset complete.
 </pre>
 </div>
 </div>

--- a/dslectures/core.py
+++ b/dslectures/core.py
@@ -15,7 +15,8 @@ def get_dataset(dataset_name: str):
 
     name_to_id = {'embeddings': '1dRwSXbFTcQbn8c3V24G92wFY4DXZ1SDt',
                   'imdb': '1wF0YEmQOwceJz2d6w4CfhBgydU87dPGl',
-                  'housing': '1d7oOKdDmZFx8wf0c8OfuTW1FpUyJHABh'}
+                  'housing': '1d7oOKdDmZFx8wf0c8OfuTW1FpUyJHABh',
+                  'housing_gmaps': '1R1RUHAXxzrIngRJMFwyp4vZRVICd-I6T'}
 
     if dataset_name in name_to_id:
         try:

--- a/notebooks/00_core.ipynb
+++ b/notebooks/00_core.ipynb
@@ -44,7 +44,8 @@
     "    \n",
     "    name_to_id = {'embeddings': '1dRwSXbFTcQbn8c3V24G92wFY4DXZ1SDt',\n",
     "                  'imdb': '1wF0YEmQOwceJz2d6w4CfhBgydU87dPGl',\n",
-    "                  'housing': '1d7oOKdDmZFx8wf0c8OfuTW1FpUyJHABh'}\n",
+    "                  'housing': '1d7oOKdDmZFx8wf0c8OfuTW1FpUyJHABh',\n",
+    "                  'housing_gmaps': '1R1RUHAXxzrIngRJMFwyp4vZRVICd-I6T'}\n",
     "    \n",
     "    if dataset_name in name_to_id:\n",
     "        try:\n",
@@ -103,8 +104,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Download of housing_gmaps dataset complete.\n"
+     ]
+    }
+   ],
+   "source": [
+    "get_dataset('housing_gmaps')"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
I added the data to gdrive and updated the core library. You can download the dataset with get_dataset('housing_gmaps'). Note that there are a few columns that are mostly empty that you might wanna drop.